### PR TITLE
Fixed code that was rooting async continuations

### DIFF
--- a/AssemblyUnloadableSignalR/AssemblyLoading/Module.cs
+++ b/AssemblyUnloadableSignalR/AssemblyLoading/Module.cs
@@ -15,9 +15,15 @@ namespace AssemblyUnloadableSignalR.AssemblyLoading
     {
         public static async Task Run<T>(string executeModule, Func<T, Task> action) where T : class
         {
-            WeakReference hostAlcWeakRef;
+            // We're not awaiting the ExecuteAndUnload because that would keep anything rooted by the stack
+            // alive. This includes thing rooted by the child ALC we just created and the ALC itself when the 
+            // continuation is being executed.
+            // RunContinuationsAsynchronously is important to resume this logic in a different stack
+            var tcs = new TaskCompletionSource<WeakReference>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            hostAlcWeakRef = await ExecuteAndUnload<T>(executeModule, executeModule, action);
+            _ = ExecuteAndUnload<T>(executeModule, executeModule, action, tcs);
+
+            WeakReference hostAlcWeakRef = await tcs.Task;
 
             for (int i = 0; hostAlcWeakRef.IsAlive && (i < 10); i++)
             {
@@ -25,48 +31,56 @@ namespace AssemblyUnloadableSignalR.AssemblyLoading
                 GC.WaitForPendingFinalizers();
             }
 
-            if(hostAlcWeakRef.IsAlive)
+            if (hostAlcWeakRef.IsAlive)
                 Console.WriteLine($"Unloading {executeModule} failed");
             else
                 Console.WriteLine($"Unloading {executeModule} succeeded");
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async Task<WeakReference> ExecuteAndUnload<T>(string modulePath, string resolvePath, Func<T, Task> action) where T : class
+        static async Task ExecuteAndUnload<T>(string modulePath, string resolvePath, Func<T, Task> action, TaskCompletionSource<WeakReference> tcs) where T : class
         {
-            var alc = new ModuleAssemblyLoadContext(resolvePath);
-
-            var typeDescriptorAssemblyPath = typeof(TypeDescriptor).Assembly.Location;
-            alc.LoadFromAssemblyPath(typeDescriptorAssemblyPath);
-            var netstandardShimAssemblyPath = Path.Combine(Path.GetDirectoryName(typeDescriptorAssemblyPath), "netstandard.dll");
-            alc.LoadFromAssemblyPath(netstandardShimAssemblyPath);
-
-            var alcWeakRef = new WeakReference(alc);
-
-            Assembly a = alc.LoadFromAssemblyPath(modulePath);
-
-            var assemblyResolverTool = new AssemblyResolverTool
+            try
             {
-                dependencyContext = DependencyContext.Load(a),
+                var alc = new ModuleAssemblyLoadContext(resolvePath);
 
-                assemblyResolver = new CompositeCompilationAssemblyResolver
-                                    (new ICompilationAssemblyResolver[]
+                var typeDescriptorAssemblyPath = typeof(TypeDescriptor).Assembly.Location;
+                alc.LoadFromAssemblyPath(typeDescriptorAssemblyPath);
+                var netstandardShimAssemblyPath = Path.Combine(Path.GetDirectoryName(typeDescriptorAssemblyPath), "netstandard.dll");
+                alc.LoadFromAssemblyPath(netstandardShimAssemblyPath);
+
+                var alcWeakRef = new WeakReference(alc);
+
+                Assembly a = alc.LoadFromAssemblyPath(modulePath);
+
+                var assemblyResolverTool = new AssemblyResolverTool
+                {
+                    dependencyContext = DependencyContext.Load(a),
+
+                    assemblyResolver = new CompositeCompilationAssemblyResolver
+                                        (new ICompilationAssemblyResolver[]
+                {
+                    new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(modulePath)),
+                    new ReferenceAssemblyPathResolver(),
+                    new PackageCompilationAssemblyResolver()
+                })
+                };
+
+                alc.Resolving += assemblyResolverTool.OnResolving;
+
+                var module = ResolveTool.ResolveInstance<T>(a);
+
+                await action(module);
+
+                alc.Resolving -= assemblyResolverTool.OnResolving;
+                alc.Unload();
+
+                tcs.TrySetResult(alcWeakRef);
+            }
+            catch (Exception ex)
             {
-            new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(modulePath)),
-            new ReferenceAssemblyPathResolver(),
-            new PackageCompilationAssemblyResolver()
-            })
-            };
-
-            alc.Resolving += assemblyResolverTool.OnResolving;
-
-            var module = ResolveTool.ResolveInstance<T>(a);
-
-            await action(module);
-
-            alc.Resolving -= assemblyResolverTool.OnResolving;
-            alc.Unload();
-            return alcWeakRef;
+                tcs.TrySetException(ex);
+            }
         }
     }
 }

--- a/Runner/Services/AgentClient.cs
+++ b/Runner/Services/AgentClient.cs
@@ -53,5 +53,12 @@ namespace Runner.Services
 
             timer.Change(Timeout.Infinite, Timeout.Infinite);
         }
+
+        public override Task StopAsync()
+        {
+            // Stop the timer here since that ends up rooting the callback in the global timer queue
+            StopTimer(_tmrConnect);
+            return base.StopAsync();
+        }
     }
 }

--- a/Runner/Services/HubClient.cs
+++ b/Runner/Services/HubClient.cs
@@ -20,7 +20,7 @@ namespace Runner.Services
             System.Console.WriteLine($"HubState = {HubConnection.State}");
         }
 
-        public async Task StopAsync()
+        public virtual async Task StopAsync()
         {
             await HubConnection.StopAsync();
             await HubConnection.DisposeAsync();


### PR DESCRIPTION
See https://github.com/dotnet/aspnetcore/issues/31637. TL;DR we need to be careful about how continuations bleeding from child ALC to the default ALC. In this case, most of the code was rooted on the stack (see the linked issue for analysis) because of how async unwinding happens. This resumes code on new frames by using a task completion source.